### PR TITLE
Add support for 1.19 Scribe elder traits

### DIFF
--- a/common/scripted_effects/restore_body_effect.txt
+++ b/common/scripted_effects/restore_body_effect.txt
@@ -35,4 +35,8 @@
 	remove_trait = lunatic_1
 	remove_trait = depressed_genetic
 	remove_trait = depressed_1
+	remove_trait = withering_mind
+	remove_trait = clouded_eyes
+	remove_trait = faltering_heart
+	remove_trait = fragile_bones
 }

--- a/common/scripted_triggers/restore_body_triggers.txt
+++ b/common/scripted_triggers/restore_body_triggers.txt
@@ -39,5 +39,9 @@
 		has_trait = lunatic_1
 		has_trait = depressed_genetic
 		has_trait = depressed_1
+		has_trait = withering_mind
+		has_trait = clouded_eyes
+		has_trait = faltering_heart
+		has_trait = fragile_bones
 	}
 }

--- a/common/traits/immortality.txt
+++ b/common/traits/immortality.txt
@@ -1,5 +1,6 @@
 ﻿immortality = {
 	immortal = yes
+	flag = is_immortal
 	health = 10
 	no_prowess_loss_from_age = yes
 	opposites = { incapable }


### PR DESCRIPTION
# Summary

Patch 1.19 Scribe added 4 new negative traits based on aging.

> Added new tiered Elder Traits: "Faltering Heart", "Fragile Bones", "Clouded Eyes", and "Withering Mind"

https://xpgained.co.uk/patch-notes/crusader-kings-iii-1-19-scribe-update-patch-notes-20th-april-2026

## is_immortal flag

This flag is used in two locations in the base game as of 1.19:

- scripted_triggers\20_health_triggers.txt

`age_ranked_health_vulnerability_threshold_trigger` as a NOT trigger.

- scripted_triggers\00_game_rule_triggers.txt

`# Immortals do not receive harm events, as they would be inevitably killed by them over a long enough period of time.`
`harm_game_rule_enablement_trigger` as a NOT trigger.

So, adding the flag will prevent age health problems, but also disable harm events.

# Testing

Tested on my local version. No errors in `error.log`.