### PR TITLE
Add a new decision group for immortality decisions

### DIFF
--- a/common/decision_group_types/immortality_decision_group.txt
+++ b/common/decision_group_types/immortality_decision_group.txt
@@ -1,0 +1,5 @@
+immortality_decision_group = {
+	sort_order = 75
+	gui_tags = { big_button }
+	important_decision_group = yes
+}

--- a/common/decision_group_types/immortality_decision_group.txt
+++ b/common/decision_group_types/immortality_decision_group.txt
@@ -1,5 +1,7 @@
-immortality_decision_group = {
+﻿immortality_decision_group = {
 	sort_order = 75
-	gui_tags = { big_button }
+	gui_tags = {
+		big_button
+	}
 	important_decision_group = yes
 }

--- a/common/decisions/immortality_decision.txt
+++ b/common/decisions/immortality_decision.txt
@@ -2,6 +2,7 @@
 	picture = {
 		reference = "gfx/interface/illustrations/decisions/decision_major_religion.dds"
 	}
+	decision_group_type = immortality_decision_group
 	is_valid_showing_failures_only = {
 		is_available_adult = yes
 	}

--- a/common/decisions/immortality_removal_decision.txt
+++ b/common/decisions/immortality_removal_decision.txt
@@ -2,6 +2,7 @@
 	picture = {
 		reference = "gfx/interface/illustrations/decisions/decision_major_religion.dds"
 	}
+	decision_group_type = immortality_decision_group
 	is_shown = {
 		has_trait = immortality
 	}

--- a/common/decisions/new_faith_creation_decision.txt
+++ b/common/decisions/new_faith_creation_decision.txt
@@ -2,7 +2,7 @@
 	picture = {
         reference = "gfx/interface/illustrations/decisions/decision_personal_religious.dds"
     }
-	
+	decision_group_type = immortality_decision_group
 	is_shown = {
 		has_character_flag = has_created_a_faith
 		OR = {

--- a/common/decisions/new_invasion_decision.txt
+++ b/common/decisions/new_invasion_decision.txt
@@ -2,7 +2,7 @@
 	picture = {
         reference = "gfx/interface/illustrations/decisions/decision_invite_knights.dds"
     }
-	
+	decision_group_type = immortality_decision_group
 	is_shown = {
 		OR = {
 			has_character_flag = used_lifetime_invasion

--- a/common/decisions/renegotiate_contract_decision.txt
+++ b/common/decisions/renegotiate_contract_decision.txt
@@ -2,6 +2,7 @@
 	picture = {
 		reference = "gfx/interface/illustrations/decisions/decision_invite_knights.dds"
 	}
+	decision_group_type = immortality_decision_group
 	cooldown = {
 		years = 15
 	}

--- a/common/decisions/restore_body_decision.txt
+++ b/common/decisions/restore_body_decision.txt
@@ -2,7 +2,7 @@
 	picture = {
         reference = "gfx/interface/illustrations/decisions/decision_major_religion.dds"
     }
-	
+	decision_group_type = immortality_decision_group
 	is_shown = {
 		restore_body_trigger = yes
 	}

--- a/common/decisions/set_age_decision.txt
+++ b/common/decisions/set_age_decision.txt
@@ -2,7 +2,7 @@
 	picture = {
         reference = "gfx/interface/illustrations/decisions/decision_major_religion.dds"
     }
-	
+	decision_group_type = immortality_decision_group
 	is_shown = {
 		OR = {
 			has_trait = immortality

--- a/localization/english/decisions_immortality_l_english.yml
+++ b/localization/english/decisions_immortality_l_english.yml
@@ -40,3 +40,5 @@
   renegotiate_contract_decision_desc: "Modifying your feudal contract from time to time is only your right as an immortal."
   renegotiate_contract_decision_effect_tooltip: "You feel empowered to modify your vassal contract again."
   renegotiate_contract_decision_confirm: "Now to have a chat with my lord..."
+
+  decision_group_type_immortality_decision_group: "Immortality Decisions"


### PR DESCRIPTION
Added a new decision group for the immortality decisions. 
Put it at 75 `sort_order` so it shows up below the realm decisions but above all the low priority ones at the bottom.

### Screenshot
<img width="546" height="169" alt="image" src="https://github.com/user-attachments/assets/f1ce6da2-7479-4dff-a09d-9976652b3a6d" />
